### PR TITLE
Implementação dos SimpleTypes

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func check(e error) {
 }
 
 func main() {
-	xmlFile, err := os.Open("mensagemSNGPC.sample.xml")
+	xmlFile, err := os.Open("mensagemSNGPCInventario.sample.xml")
 	check(err)
 
 	dec := xml.NewDecoder(xmlFile)
@@ -38,22 +38,22 @@ func main() {
 		_, err = xmlFile.Seek(0, 0)
 		check(err)
 
-		sngpc := sngpc.MensagemSNGPCInventario{}
+		mysngpc := sngpc.MensagemSNGPCInventario{}
 
-		err = dec.Decode(&sngpc)
+		err = dec.Decode(&mysngpc)
 		check(err)
 
-		fmt.Printf("\n%s", sngpc)
+		fmt.Printf("\n%s", mysngpc)
 	} else if strings.Contains(string(buffer), `<mensagemSNGPC xmlns="urn:sngpc-schema">`) {
 		_, err = xmlFile.Seek(0, 0)
 		check(err)
 
-		sngpc := sngpc.MensagemSNGPC{}
+		mysngpc := sngpc.MensagemSNGPC{}
 
-		err = dec.Decode(&sngpc)
+		err = dec.Decode(&mysngpc)
 		check(err)
 
-		fmt.Printf("\n%s", sngpc)
+		fmt.Printf("\n%s", mysngpc)
 	}
 
 }

--- a/sngpc/complex_types.go
+++ b/sngpc/complex_types.go
@@ -1,7 +1,5 @@
 package sngpc
 
-import "fmt"
-
 //Medicamento
 // <complexType name="ct_Medicamento">
 //     <sequence>
@@ -12,10 +10,10 @@ import "fmt"
 //     </sequence>
 //   </complexType>
 type Medicamento struct {
-	RegistroMSMedicamento    string `xml:"registroMSMedicamento"`
-	NumeroLoteMedicamento    string `xml:"numeroLoteMedicamento"`
-	QuantidadeMedicamento    string `xml:"quantidadeMedicamento"`
-	UnidadeMedidaMedicamento string `xml:"unidadeMedidaMedicamento"`
+	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
+	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
+	QuantidadeMedicamento    string                   `xml:"quantidadeMedicamento"`
+	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
 }
 
 //MedicamentoVenda
@@ -29,33 +27,11 @@ type Medicamento struct {
 // </sequence>
 // </complexType>
 type MedicamentoVenda struct {
-	UsoProlongado            string `xml:"usoProlongado"`
-	RegistroMSMedicamento    string `xml:"registroMSMedicamento"`
-	NumeroLoteMedicamento    string `xml:"numeroLoteMedicamento"`
-	QuantidadeMedicamento    uint   `xml:"quantidadeMedicamento"`
-	UnidadeMedidaMedicamento uint8  `xml:"unidadeMedidaMedicamento"`
-}
-
-//MedicamentoEntrada type struct
-// <complexType name="ct_MedicamentoEntrada">
-// <sequence>
-//   <element name="classeTerapeutica" type="sngpc:st_classeTerapeutica" />
-//   <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
-//   <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
-//   <element name="quantidadeMedicamento" type="sngpc:st_QuantidadeMedicamento" />
-//   <element name="unidadeMedidaMedicamento" type="sngpc:st_UnidadeMedidaMedicamento" />
-// </sequence>
-// </complexType>
-type MedicamentoEntrada struct {
-	ClasseTerapeutica        uint8  `xml:"classeTerapeutica"`
-	RegistroMSMedicamento    string `xml:"registroMSMedicamento"`
-	NumeroLoteMedicamento    string `xml:"numeroLoteMedicamento"`
-	QuantidadeMedicamento    uint   `xml:"quantidadeMedicamento"`
-	UnidadeMedidaMedicamento uint8  `xml:"unidadeMedidaMedicamento"`
-}
-
-func (s MedicamentoEntrada) String() string {
-	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v\n", s.RegistroMSMedicamento, s.NumeroLoteMedicamento, s.QuantidadeMedicamento)
+	UsoProlongado            string                   `xml:"usoProlongado"`
+	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
+	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
+	QuantidadeMedicamento    uint                     `xml:"quantidadeMedicamento"`
+	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
 }
 
 //NotaFiscal
@@ -86,16 +62,15 @@ type NotaFiscal struct {
 // </sequence>
 // </complexType>
 type MedicamentoSaidaTransformacao struct {
-	RegistroMSMedicamento   string  `xml:"registroMSMedicamento"`
-	NumeroLoteMedicamento   string  `xml:"numeroLoteMedicamento"`
-	QuantidadeInsumo        float32 `xml:"quantidadeInsumo"`
-	UnidadeDeMedidaDoInsumo uint8   `xml:"unidadeDeMedidaDoInsumo"`
+	RegistroMSMedicamento   string            `xml:"registroMSMedicamento"`
+	NumeroLoteMedicamento   string            `xml:"numeroLoteMedicamento"`
+	QuantidadeInsumo        float32           `xml:"quantidadeInsumo"`
+	UnidadeDeMedidaDoInsumo TipoUnidadeInsumo `xml:"unidadeDeMedidaDoInsumo"`
 }
 
 //MedicamentoTransformacao
 // <complexType name="ct_MedicamentoTransformacao">
 // <sequence>
-//   <!--<element name="classeTerapeutica" type = "sngpc:st_classeTerapeutica" />-->
 //   <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
 //   <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
 //   <element name="quantidadeMedicamento" type="sngpc:st_QuantidadeMedicamento" />
@@ -105,12 +80,12 @@ type MedicamentoSaidaTransformacao struct {
 // </sequence>
 // </complexType>
 type MedicamentoTransformacao struct {
-	RegistroMSMedicamento    string  `xml:"registroMSMedicamento"`
-	NumeroLoteMedicamento    string  `xml:"numeroLoteMedicamento"`
-	QuantidadeMedicamento    string  `xml:"quantidadeMedicamento"`
-	UnidadeMedidaMedicamento string  `xml:"unidadeMedidaMedicamento"`
-	QuantidadeInsumo         float32 `xml:"quantidadeInsumo"`
-	UnidadeDeMedidaDoInsumo  string  `xml:"unidadeDeMedidaDoInsumo"`
+	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
+	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
+	QuantidadeMedicamento    string                   `xml:"quantidadeMedicamento"`
+	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
+	QuantidadeInsumo         float32                  `xml:"quantidadeInsumo"`
+	UnidadeDeMedidaDoInsumo  TipoUnidadeInsumo        `xml:"unidadeDeMedidaDoInsumo"`
 }
 
 //MedicamentoTransformacaoVenda
@@ -126,13 +101,13 @@ type MedicamentoTransformacao struct {
 // </sequence>
 // </complexType>
 type MedicamentoTransformacaoVenda struct {
-	UsoProlongado                              string  `xml:"usoProlongado"`
-	RegistroMSMedicamento                      string  `xml:"registroMSMedicamento"`
-	NumeroLoteMedicamento                      string  `xml:"numeroLoteMedicamento"`
-	QuantidadeDeInsumoPorUnidadeFarmacotecnica float32 `xml:"quantidadeDeInsumoPorUnidadeFarmacotecnica"`
-	UnidadeDeMedidaDoInsumo                    uint8   `xml:"unidadeDeMedidaDoInsumo"`
-	UnidadeFarmacotecnica                      uint8   `xml:"unidadeFarmacotecnica"`
-	QuantidadeDeUnidadesFarmacotecnicas        float32 `xml:"quantidadeDeUnidadesFarmacotecnicas"`
+	UsoProlongado                              string                    `xml:"usoProlongado"`
+	RegistroMSMedicamento                      string                    `xml:"registroMSMedicamento"`
+	NumeroLoteMedicamento                      string                    `xml:"numeroLoteMedicamento"`
+	QuantidadeDeInsumoPorUnidadeFarmacotecnica float32                   `xml:"quantidadeDeInsumoPorUnidadeFarmacotecnica"`
+	UnidadeDeMedidaDoInsumo                    TipoUnidadeInsumo         `xml:"unidadeDeMedidaDoInsumo"`
+	UnidadeFarmacotecnica                      TipoUnidadeFarmacotecnica `xml:"unidadeFarmacotecnica"`
+	QuantidadeDeUnidadesFarmacotecnicas        float32                   `xml:"quantidadeDeUnidadesFarmacotecnicas"`
 }
 
 //Insumo
@@ -158,9 +133,9 @@ type Insumo struct {
 //     </sequence>
 //   </complexType>
 type InsumoEntrada struct {
-	InsumoEntrada           Insumo  `xml:"insumoEntrada"`
-	QuantidadeInsumoEntrada float32 `xml:"quantidadeInsumoEntrada"`
-	TipoUnidadeEntrada      uint8   `xml:"tipoUnidadeEntrada"`
+	InsumoEntrada           Insumo            `xml:"insumoEntrada"`
+	QuantidadeInsumoEntrada float32           `xml:"quantidadeInsumoEntrada"`
+	TipoUnidadeEntrada      TipoUnidadeInsumo `xml:"tipoUnidadeEntrada"`
 }
 
 //InsumoTransferencia
@@ -172,9 +147,9 @@ type InsumoEntrada struct {
 // </sequence>
 // </complexType>
 type InsumoTransferencia struct {
-	InsumoTransferencia           Insumo  `xml:"insumoTransferencia"`
-	QuantidadeInsumoTransferencia float32 `xml:"quantidadeInsumoTransferencia"`
-	TipoUnidadeTransferencia      uint8   `xml:"tipoUnidadeTransferencia"`
+	InsumoTransferencia           Insumo            `xml:"insumoTransferencia"`
+	QuantidadeInsumoTransferencia float32           `xml:"quantidadeInsumoTransferencia"`
+	TipoUnidadeTransferencia      TipoUnidadeInsumo `xml:"tipoUnidadeTransferencia"`
 }
 
 //InsumoPerda
@@ -186,9 +161,9 @@ type InsumoTransferencia struct {
 // </sequence>
 // </complexType>
 type InsumoPerda struct {
-	InsumoPerda           Insumo  `xml:"insumoPerda"`
-	QuantidadeInsumoPerda float32 `xml:"quantidadeInsumoPerda"`
-	TipoUnidadePerda      uint8   `xml:"tipoUnidadePerda"`
+	InsumoPerda           Insumo            `xml:"insumoPerda"`
+	QuantidadeInsumoPerda float32           `xml:"quantidadeInsumoPerda"`
+	TipoUnidadePerda      TipoUnidadeInsumo `xml:"tipoUnidadePerda"`
 }
 
 //InsumoVendaAoConsumidor
@@ -203,12 +178,12 @@ type InsumoPerda struct {
 // </sequence>
 // </complexType>
 type InsumoVendaAoConsumidor struct {
-	UsoProlongado                              uint8  `xml:"usoProlongado"`
-	InsumoVendaAoConsumidor                    Insumo `xml:"insumoVendaAoConsumidor"`
-	QuantidadeDeInsumoPorUnidadeFarmacotecnica string `xml:"quantidadeDeInsumoPorUnidadeFarmacotecnica"`
-	UnidadeDeMedidaDoInsumo                    string `xml:"unidadeDeMedidaDoInsumo"`
-	UnidadeFarmacotecnica                      string `xml:"unidadeFarmacotecnica"`
-	QuantidadeDeUnidadesFarmacotecnicas        string `xml:"quantidadeDeUnidadesFarmacotecnicas"`
+	UsoProlongado                              uint8                     `xml:"usoProlongado"`
+	InsumoVendaAoConsumidor                    Insumo                    `xml:"insumoVendaAoConsumidor"`
+	QuantidadeDeInsumoPorUnidadeFarmacotecnica string                    `xml:"quantidadeDeInsumoPorUnidadeFarmacotecnica"`
+	UnidadeDeMedidaDoInsumo                    TipoUnidadeInsumo         `xml:"unidadeDeMedidaDoInsumo"`
+	UnidadeFarmacotecnica                      TipoUnidadeFarmacotecnica `xml:"unidadeFarmacotecnica"`
+	QuantidadeDeUnidadesFarmacotecnicas        float32                   `xml:"quantidadeDeUnidadesFarmacotecnicas"`
 }
 
 //Comprador
@@ -222,11 +197,11 @@ type InsumoVendaAoConsumidor struct {
 // </sequence>
 // </complexType>
 type Comprador struct {
-	NomeComprador      string `xml:"nomeComprador"`
-	TipoDocumento      uint8  `xml:"tipoDocumento"`
-	NumeroDocumento    string `xml:"numeroDocumento"`
-	OrgaoExpedidor     string `xml:"orgaoExpedidor"`
-	UFEmissaoDocumento string `xml:"UFEmissaoDocumento"`
+	NomeComprador      string         `xml:"nomeComprador"`
+	TipoDocumento      TipoDocumento  `xml:"tipoDocumento"`
+	NumeroDocumento    string         `xml:"numeroDocumento"`
+	OrgaoExpedidor     OrgaoExpedidor `xml:"orgaoExpedidor"`
+	UFEmissaoDocumento UF             `xml:"UFEmissaoDocumento"`
 }
 
 //Prescritor
@@ -239,10 +214,10 @@ type Comprador struct {
 //     </sequence>
 //   </complexType>
 type Prescritor struct {
-	NomePrescritor             string `xml:"nomePrescritor"`
-	NumeroRegistroProfissional string `xml:"numeroRegistroProfissional"`
-	ConselhoProfissional       string `xml:"conselhoProfissional"`
-	UFConselho                 string `xml:"UFConselho"`
+	NomePrescritor             string               `xml:"nomePrescritor"`
+	NumeroRegistroProfissional string               `xml:"numeroRegistroProfissional"`
+	ConselhoProfissional       ConselhoProfissional `xml:"conselhoProfissional"`
+	UFConselho                 UF                   `xml:"UFConselho"`
 }
 
 // ct_Retorno
@@ -271,11 +246,11 @@ type Prescritor struct {
 // </sequence>
 // </complexType>
 type Paciente struct {
-	Nome         string `xml:"nome"`
-	Idade        string `xml:"idade"`
-	UnidadeIdade string `xml:"unidadeIdade"`
-	Sexo         string `xml:"sexo"`
-	Cid          string `xml:"cid"`
+	Nome         string       `xml:"nome"`
+	Idade        string       `xml:"idade"`
+	UnidadeIdade UnidadeIdade `xml:"unidadeIdade"`
+	Sexo         Sexo         `xml:"sexo"`
+	Cid          string       `xml:"cid"`
 }
 
 //InsumoBasico
@@ -289,33 +264,9 @@ type Paciente struct {
 // </sequence>
 // </complexType>
 type InsumoBasico struct {
-	CodigoInsumo         string  `xml:"codigoInsumo"`
-	NumeroLoteInsumo     string  `xml:"numeroLoteInsumo"`
-	InsumoCNPJFornecedor string  `xml:"insumoCNPJFornecedor"`
-	QuantidadeInsumo     float32 `xml:"quantidadeInsumo"`
-	TipoUnidade          uint8   `xml:"tipoUnidade"`
-}
-
-//InsumoBasicoEntrada
-// <complexType name="ct_InsumoBasicoEntrada">
-// <sequence>
-//   <element name="classeTerapeutica" type="sngpc:st_classeTerapeutica" />
-//   <element name="codigoInsumo" type="sngpc:st_CodigoDCB" />
-//   <element name="numeroLoteInsumo" type="sngpc:st_Lote" />
-//   <element name="insumoCNPJFornecedor" type="sngpc:st_CNPJ" />
-//   <element name="quantidadeInsumo" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="tipoUnidade" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
-type InsumoBasicoEntrada struct {
-	ClasseTerapeutica    ClasseTerapeutica `xml:"classeTerapeutica"`
 	CodigoInsumo         string            `xml:"codigoInsumo"`
 	NumeroLoteInsumo     string            `xml:"numeroLoteInsumo"`
 	InsumoCNPJFornecedor string            `xml:"insumoCNPJFornecedor"`
 	QuantidadeInsumo     float32           `xml:"quantidadeInsumo"`
-	UnidadeMedidaInsumo  uint8             `xml:"unidadeMedidaInsumo"`
-}
-
-func (s InsumoBasicoEntrada) String() string {
-	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v\n", s.CodigoInsumo, s.NumeroLoteInsumo, s.QuantidadeInsumo)
+	TipoUnidade          TipoUnidadeInsumo `xml:"tipoUnidade"`
 }

--- a/sngpc/inventario.go
+++ b/sngpc/inventario.go
@@ -2,34 +2,76 @@ package sngpc
 
 import "fmt"
 
-//MensagemSNGPCInventario
 type MensagemSNGPCInventario struct {
 	Cabecalho CabecalhoInventario `xml:"cabecalho"`
 	Corpo     CorpoInventario     `xml:"corpo"`
 }
 
-//CabecalhoInventario
+func (s MensagemSNGPCInventario) String() string {
+	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
+}
+
 type CabecalhoInventario struct {
 	CnpjEmissor    string `xml:"cnpjEmissor"`
 	CpfTransmissor string `xml:"cpfTransmissor"`
 	Data           string `xml:"data"`
 }
 
-//Corpo
+func (s CabecalhoInventario) String() string {
+	return fmt.Sprintf("Inventário :\n\nCNPJ : %v ; CPF : %v ; Data : %v\n", s.CnpjEmissor, s.CpfTransmissor, s.Data)
+}
+
 type CorpoInventario struct {
 	Medicamentos Medicamentos `xml:"medicamentos"`
 	Insumos      Insumos      `xml:"insumos"`
 }
 
-//Inventario
-func (s MensagemSNGPCInventario) String() string {
-	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
-}
-
-func (s CabecalhoInventario) String() string {
-	return fmt.Sprintf("Inventário :\n\nCNPJ : %v ; CPF : %v ; Data : %v\n", s.CnpjEmissor, s.CpfTransmissor, s.Data)
-}
-
 func (s CorpoInventario) String() string {
 	return fmt.Sprintf("Corpo : \n\nMedicamentos : \n%v\nInsumos : \n%v\n", s.Medicamentos, s.Insumos)
+}
+
+//MedicamentoEntrada type struct
+// <complexType name="ct_MedicamentoEntrada">
+// <sequence>
+//   <element name="classeTerapeutica" type="sngpc:st_classeTerapeutica" />
+//   <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
+//   <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
+//   <element name="quantidadeMedicamento" type="sngpc:st_QuantidadeMedicamento" />
+//   <element name="unidadeMedidaMedicamento" type="sngpc:st_UnidadeMedidaMedicamento" />
+// </sequence>
+// </complexType>
+type MedicamentoEntrada struct {
+	ClasseTerapeutica        ClasseTerapeutica        `xml:"classeTerapeutica"`
+	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
+	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
+	QuantidadeMedicamento    uint                     `xml:"quantidadeMedicamento"`
+	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
+}
+
+func (s MedicamentoEntrada) String() string {
+	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v\n", s.RegistroMSMedicamento, s.NumeroLoteMedicamento, s.QuantidadeMedicamento)
+}
+
+//InsumoBasicoEntrada
+// <complexType name="ct_InsumoBasicoEntrada">
+// <sequence>
+//   <element name="classeTerapeutica" type="sngpc:st_classeTerapeutica" />
+//   <element name="codigoInsumo" type="sngpc:st_CodigoDCB" />
+//   <element name="numeroLoteInsumo" type="sngpc:st_Lote" />
+//   <element name="insumoCNPJFornecedor" type="sngpc:st_CNPJ" />
+//   <element name="quantidadeInsumo" type="sngpc:st_QuantidadeInsumo" />
+//   <element name="tipoUnidade" type="sngpc:st_TipoUnidadeInsumo" />
+// </sequence>
+// </complexType>
+type InsumoBasicoEntrada struct {
+	ClasseTerapeutica    ClasseTerapeutica `xml:"classeTerapeutica"`
+	CodigoInsumo         string            `xml:"codigoInsumo"`
+	NumeroLoteInsumo     string            `xml:"numeroLoteInsumo"`
+	InsumoCNPJFornecedor string            `xml:"insumoCNPJFornecedor"`
+	QuantidadeInsumo     float32           `xml:"quantidadeInsumo"`
+	UnidadeMedidaInsumo  TipoUnidadeInsumo `xml:"unidadeMedidaInsumo"`
+}
+
+func (s InsumoBasicoEntrada) String() string {
+	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v, Unidade: %v\n", s.CodigoInsumo, s.NumeroLoteInsumo, s.QuantidadeInsumo, s.UnidadeMedidaInsumo)
 }

--- a/sngpc/movimentacao.go
+++ b/sngpc/movimentacao.go
@@ -8,10 +8,8 @@ type MensagemSNGPC struct {
 	Corpo     CorpoMovimentacao     `xml:"corpo"`
 }
 
-//Corpo
-type CorpoMovimentacao struct {
-	Medicamentos Medicamentos `xml:"medicamentos"`
-	Insumos      Insumos      `xml:"insumos"`
+func (s MensagemSNGPC) String() string {
+	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
 }
 
 //CabecalhoMovimentacao
@@ -30,6 +28,37 @@ type CabecalhoMovimentacao struct {
 	DataFim        string `xml:"dataFim"`
 }
 
+func (s CabecalhoMovimentacao) String() string {
+	return fmt.Sprintf("cnpj : %v ; cpf : %v ; inicio : %v, fim : %v\n", s.CnpjEmissor, s.CpfTransmissor, s.DataInicio, s.DataFim)
+}
+
+//Corpo
+type CorpoMovimentacao struct {
+	Medicamentos Medicamentos `xml:"medicamentos"`
+	Insumos      Insumos      `xml:"insumos"`
+}
+
+func (s CorpoMovimentacao) String() string {
+	out := "Corpo : \n"
+
+	for _, s := range s.Medicamentos.EntradaMedicamentos {
+		out += "EntradaMedicamentos : \n"
+		out += fmt.Sprintf("NF : %v, Data: %v\n", s.NotaFiscalEntradaMedicamento.NumeroNotaFiscal, s.DataRecebimentoMedicamento)
+		for _, m := range s.MedicamentoEntrada {
+			out += fmt.Sprintf("Medicamento : %v, Lote : %v, Quantidade : %v, Classe : %v\n", m.RegistroMSMedicamento, m.NumeroLoteMedicamento, m.QuantidadeMedicamento, m.ClasseTerapeutica)
+		}
+	}
+
+	for _, s := range s.Medicamentos.SaidaMedicamentoVendaAoConsumidor {
+		out += "SaidaMedicamentoVendaAoConsumidor : \n"
+		out += fmt.Sprintf("Data : %v\n", s.DataVendaMedicamento)
+		for _, m := range s.MedicamentoVenda {
+			out += fmt.Sprintf("Medicamento : %v, Lote : %v, Quantidade : %v\n", m.RegistroMSMedicamento, m.NumeroLoteMedicamento, m.QuantidadeMedicamento)
+		}
+	}
+	return out
+}
+
 //Insumos
 // <element name="insumos">
 // <complexType>
@@ -41,7 +70,6 @@ type CabecalhoMovimentacao struct {
 //   </sequence>
 // </complexType>
 // </element>
-
 type Insumos struct {
 	EntradaInsumos               []EntradaInsumo            `xml:"entradaInsumos"`
 	SaidaInsumoVendaAoConsumidor []SaidaInsumoVenda         `xml:"saidaInsumoVendaAoConsumidor"`
@@ -90,34 +118,5 @@ func (s Medicamentos) String() string {
 		out += fmt.Sprint(e.MedicamentoEntrada)
 	}
 
-	return out
-}
-
-func (s MensagemSNGPC) String() string {
-	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
-}
-
-func (s CabecalhoMovimentacao) String() string {
-	return fmt.Sprintf("cnpj : %v ; cpf : %v ; inicio : %v, fim : %v\n", s.CnpjEmissor, s.CpfTransmissor, s.DataInicio, s.DataFim)
-}
-
-func (s CorpoMovimentacao) String() string {
-	out := "Corpo : \n"
-
-	for _, s := range s.Medicamentos.EntradaMedicamentos {
-		out += "EntradaMedicamentos : \n"
-		out += fmt.Sprintf("NF : %v, Data: %v\n", s.NotaFiscalEntradaMedicamento.NumeroNotaFiscal, s.DataRecebimentoMedicamento)
-		for _, m := range s.MedicamentoEntrada {
-			out += fmt.Sprintf("Medicamento : %v, Lote : %v, Quantidade : %v\n", m.RegistroMSMedicamento, m.NumeroLoteMedicamento, m.QuantidadeMedicamento)
-		}
-	}
-
-	for _, s := range s.Medicamentos.SaidaMedicamentoVendaAoConsumidor {
-		out += "SaidaMedicamentoVendaAoConsumidor : \n"
-		out += fmt.Sprintf("Data : %v\n", s.DataVendaMedicamento)
-		for _, m := range s.MedicamentoVenda {
-			out += fmt.Sprintf("Medicamento : %v, Lote : %v, Quantidade : %v\n", m.RegistroMSMedicamento, m.NumeroLoteMedicamento, m.QuantidadeMedicamento)
-		}
-	}
 	return out
 }

--- a/sngpc/simple_types.go
+++ b/sngpc/simple_types.go
@@ -1,32 +1,307 @@
 package sngpc
 
-//ClasseTerapeutica
-// <simpleType name="st_classeTerapeutica">
-// <restriction base="string">
-//   <!--Antimicrobiano-->
-//   <enumeration value="1" />
-//   <!--Sujeito a controle Especial-->
-//   <enumeration value="2" />
-// </restriction>
-// </simpleType>
+//st_classeTerapeutica
 type ClasseTerapeutica uint8
 
-const (
-	Antimicrobiano           ClasseTerapeutica = 1
-	SujeitoAControleEspecial ClasseTerapeutica = 2
-)
+var classeTerapeutica = map[ClasseTerapeutica]string{
+	1: "Antimicrobiano",
+	2: "Sujeito a Controle Especial",
+}
 
-type UnidadeMedidaMedicamento uint8
+func (s ClasseTerapeutica) String() string {
+	return classeTerapeutica[s]
+}
 
-const (
-	Caixas  UnidadeMedidaMedicamento = 1
-	Frascos UnidadeMedidaMedicamento = 2
-)
+// st_data
+// st_CPF
+// st_CNPJ
+// st_RazaoSocial
+// st_AES
+// st_simNao
+// st_SimNaoNull
+// st_NumeroNotaFiscal
+// st_QuantidadeMedicamento
+// st_QuantidadeGramasMedicamento
+// st_Notificacao
+// st_RegistroMS
+// st_CodigoDCB
+// st_Nome
+// st_NumeroDocumento
+// st_Lote
+// st_QuantidadeInsumo
+// st_QuantidadeDeInsumoPorUnidadeFarmacotecnica
+// st_QuantidadeDeUnidadesFarmacotecnicas
 
+//st_TipoReceituario
+type TipoReceituario uint8
+
+var tipoReceituario = map[TipoReceituario]string{
+	1: "Receita de Controle Especial em 2 vias (Receita Branca)",
+	2: "Notificação de Receita B (Notificação Azul",
+	3: "Notificação de Receita Especial (Notificação Branca)",
+	4: "Notificação de Receita A (Notificação Amarela)",
+	5: "Receita Antimicrobiano em 2 vias",
+}
+
+func (s TipoReceituario) String() string {
+	return tipoReceituario[s]
+}
+
+//st_TipoUsoMedicamento
+type TipoUsoMedicamento uint8
+
+var tipoUsoMedicamento = map[TipoUsoMedicamento]string{
+	1: "Humano",
+	2: "Veterinário",
+}
+
+func (s TipoUsoMedicamento) String() string {
+	return tipoUsoMedicamento[s]
+}
+
+// st_TipoOperacaoNotaFiscal
+type TipoOperacaoNotaFiscal uint8
+
+var tipoOperacaoNotaFiscal = map[TipoOperacaoNotaFiscal]string{
+	1: "Compra",
+	2: "Transferência",
+	3: "Venda",
+}
+
+func (s TipoOperacaoNotaFiscal) String() string {
+	return tipoOperacaoNotaFiscal[s]
+}
+
+// st_ConselhoProfissional
+type ConselhoProfissional string
+
+var conselhoProfissional = map[ConselhoProfissional]string{
+	"CRM":  "Conselho Regional de Medicida",
+	"CRMV": "Conselho Regional de Medicina Veterinária",
+	"CRO":  "Conselho Regional de Odontologia",
+	"CRF":  "Conselho Regional de Farmácia",
+	"RMS":  "Programa Mais Medicos - Registro Ministério da Saúde",
+}
+
+func (s ConselhoProfissional) String() string {
+	return conselhoProfissional[s]
+}
+
+// st_UF
+type UF string
+
+var uf = map[UF]string{
+	"AC": "Acre",
+	"AL": "Alagoas",
+	"AM": "Amazonas",
+	"AP": "Amapa",
+	"BA": "Bahia",
+	"CE": "Ceara",
+	"DF": "Distrito Federal",
+	"ES": "Espirito Santo",
+	"GO": "Goias",
+	"MA": "Maranhao",
+	"MG": "Minas Gerais",
+	"MS": "Mato Grosso do Sul",
+	"MT": "Mato Grosso",
+	"PA": "Para",
+	"PB": "Paraiba",
+	"PE": "Pernambuco",
+	"PI": "Piaui",
+	"PR": "Parana",
+	"RJ": "Rio de Janeiro",
+	"RN": "Rio Grande do Norte",
+	"RO": "Rondonia",
+	"RR": "Roraima",
+	"RS": "Rio Grande do Sul",
+	"SC": "Santa Catarina",
+	"SE": "Sergipe",
+	"SP": "Sao Paulo",
+	"TO": "Tocantins",
+}
+
+func (s UF) String() string {
+	return uf[s]
+}
+
+// st_TipoMotivoPerda
+type TipoMotivoPerda uint8
+
+var tipoMotivoPerda = map[TipoMotivoPerda]string{
+	1:  "Furto / Roubo",
+	2:  "Avaria",
+	3:  "Vencimento",
+	4:  "Apreensão / Recolhimento pela Visa",
+	5:  "Perda no processo",
+	6:  "Coleta para controle de qualidade",
+	7:  "Perda de exclusão da portaria 344",
+	8:  "Por desvio de qualidade",
+	9:  "Recolhimento do Fabricante",
+	10: "Devolução ao fornecedor/distribuidora",
+}
+
+func (s TipoMotivoPerda) String() string {
+	return tipoMotivoPerda[s]
+}
+
+// st_TipoUnidadeInsumo
 type TipoUnidadeInsumo uint8
 
-const (
-	Grama     TipoUnidadeInsumo = 1
-	Mililitro TipoUnidadeInsumo = 2
-	Unidade   TipoUnidadeInsumo = 3
-)
+var tipoUnidadeInsumo = map[TipoUnidadeInsumo]string{
+	1: "Grama",
+	2: "Mililitro",
+	3: "Unidade (U)",
+}
+
+func (s TipoUnidadeInsumo) String() string {
+	return tipoUnidadeInsumo[s]
+}
+
+// st_TipoUnidadeFarmacotecnica
+type TipoUnidadeFarmacotecnica uint8
+
+var tipoUnidadeFarmacotecnica = map[TipoUnidadeFarmacotecnica]string{
+	1: "Grama",
+	2: "Cápsula",
+	3: "Comprimido",
+	4: "Mililitro",
+}
+
+func (s TipoUnidadeFarmacotecnica) String() string {
+	return tipoUnidadeFarmacotecnica[s]
+}
+
+// st_TipoDocumento
+type TipoDocumento uint8
+
+var tipoDocumento = map[TipoDocumento]string{
+	1:  "CARTEIRA DE REGISTRO PROFISSIONAL",
+	2:  "CARTEIRA DE IDENTIDADE",
+	4:  "PEDIDO DE AUTORIZAÇÃO DE TRABALHO",
+	5:  "CERTIDÃO DE NASCIMENTO",
+	6:  "CERTIDÃO DE CASAMENTO",
+	7:  "CERTIFICADO DE RESERVISTA",
+	8:  "CARTA PATENTE",
+	10: "CERTIFICADO DE DISPENSA DE INCORPORAÇÃO",
+	11: "CARTEIRA DE IDENTIDADE DO ESTRANGEIRO",
+	13: "PASSAPORTE",
+	14: "PROTOCOLO DA POLÍCIA FEDERAL",
+	19: "INSCRIÇÃO ESTADUAL",
+	20: "INSCRIÇÃO MUNICIPAL",
+	21: "ALVARÁ/LICENÇA SANITÁRIA MUNICIPAL",
+	22: "ALVARA/LICENÇA SANITÁRIA ESTADUAL",
+	38: "AUTORIZAÇÃO DE FUNCIONAMENTO DE EMPRESA",
+	39: "AUTORIZAÇÃO ESPECIAL DE FUNCIONAMENTO",
+	40: "AUTORIZAÇÃO ESPECIAL SIMPLIFICADA",
+	50: "CARTEIRA DE TRABALHO E PREVIDÊNCIA SOCIAL",
+	62: "CADASTRO NACIONAL DE PESSOA JURIDICA",
+}
+
+func (s TipoDocumento) String() string {
+	return tipoDocumento[s]
+}
+
+// st_OrgaoExpedidor
+type OrgaoExpedidor string
+
+var orgaoExpedidor = map[OrgaoExpedidor]string{
+	"CRA":     "CONSELHO REGIONAL DE ADMINISTRAÇÃO",
+	"CRE":     "CONSELHO REGIONAL DE ECONOMIA",
+	"CREA":    "CONSELHO REG.DE ENG. ARQUIT. E AGRONOMIA",
+	"CRF":     "CONSELHO REGIONAL DE FARMÁCIA",
+	"DGPC":    "DIRETORIA GERAL DA POLÍCIA CIVIL",
+	"DPF":     "DEPARTAMENTO DE POLÍCIA FEDERAL",
+	"IDAMP":   "INSTITUTO IDENTIF. AROLDO MENDES PAIVA",
+	"IFP":     "INSTITUTO FÉLIX PACHECO",
+	"IN":      "IMPRENSA NACIONAL",
+	"JUNTA":   "JUNTA",
+	"MAER":    "MINISTÉRIO DA AERONÁUTICA",
+	"MEX":     "MINISTÉRIO DO EXÉRCITO",
+	"MM":      "MINISTÉRIO DA MARINHA",
+	"OAB":     "ORDEM DOS ADVOGADOS DO BRASIL",
+	"SEJSP":   "SECRETARIA DE EST. DA JUSTIÇA E SEG. PUB",
+	"SES":     "SECRETARIA DE ESTADO DA SEGURANÇA",
+	"SESP":    "SECRETARIA DO ESTADO SEG. PÚBLICA",
+	"SJS":     "SECRETARIA DA JUSTIÇA E DA SEGURANÇA",
+	"SJTC":    "SECR. DA JUST. DO TRAB. E DA CIDADANIA",
+	"SSIPT":   "SECR.  DE SEG. E INFORM. POLÍCIA TÉCNICA",
+	"SSP":     "SECRETARIA DE SEGURANÇA PÚBLICA",
+	"VACIV":   "VARA CIVIL",
+	"VAMEN":   "VARA DE MENORES",
+	"PM":      "POLICIA MILITAR",
+	"ITB":     "INSTITUTO TAVARES BURIL",
+	"CRM":     "CONSELHO REGIONAL DE MEDICINA",
+	"CBM":     "CORPO DE BOMBEIROS MILITAR",
+	"DIC":     "DETRAN - DIRETORIA DE IDENTIFICAÇÃO CIVIL",
+	"CFP":     "CONSELHO FEDERAL DE PSICOLOGIA",
+	"CRO":     "CONSELHO REGIONAL DE ODONTOLOGIA",
+	"COREN":   "CONSELHO REGIONAL DE ENFERMARIA",
+	"CFN":     "CONSELHO FEDERAL DE NUTRICIONISTAS",
+	"MRE":     "MINISTÉRIO DAS RELAÇÕES EXTERIORES",
+	"CRCI":    "CONSELHO REG. DE CORRETORES DE IMÓVEIS",
+	"CRB":     "CONSELHO REGIONAL DE BIOLOGIA",
+	"CRN":     "CONSELHO REGIONAL DE NUTRIÇÃO",
+	"CFE":     "CONSELHO FEDERAL DE ENFERMAGEM",
+	"CRC":     "CONSELHO REGIONAL DE CONTABILIDADE",
+	"CRP":     "CONSELHO REGIONAL DE PSICOLOGIA",
+	"CRQ":     "CONSELHO REGIONAL DE QUIMICA",
+	"ANVISA":  "AGÊNCIA NACIONAL DE VIGILÂNCIA SANITÁRIA",
+	"GOVEST":  "GOVERNO DO ESTADO",
+	"PREF":    "PREFEITURA",
+	"CRBM":    "CONSELHO REGIONAL DE BIOMEDICINA",
+	"IPF":     "INSTITUTO PEREIRA FAUSTINO",
+	"CREFITO": "CONSELHO REGIONAL DE FISIOTERAPIA E TERAPIA OCUPACIONAL",
+	"CRMV":    "CONSELHO REGIONAL DE MEDICINA VETERINÁRIA",
+	"MTE":     "MINISTÉRIO DO TRABALHO E EMPREGO",
+	"CRFA":    "CONSELHO REGIONAL DE FONOAUDIOLOGIA",
+	"CORECON": "CONSELHO REGIONAL DE ECONOMIA",
+	"SDS":     "SECRETARIA DE DESENVOLVIMENTO SOCIAL",
+	"SRF":     "SECRETARIA DA RECEITA FEDERAL",
+}
+
+func (s OrgaoExpedidor) String() string {
+	return orgaoExpedidor[s]
+}
+
+// st_DescricaoValidacao
+
+// st_Idade
+type Idade uint8
+
+// st_UnidadeIdade
+type UnidadeIdade uint8
+
+var unidadeIdade = map[UnidadeIdade]string{
+	1: "Anos",
+	2: "Meses",
+}
+
+func (s UnidadeIdade) String() string {
+	return unidadeIdade[s]
+}
+
+// st_Sexo
+type Sexo uint8
+
+var sexo = map[Sexo]string{
+	1: "Masculino",
+	2: "Feminino",
+}
+
+func (s Sexo) String() string {
+	return sexo[s]
+}
+
+// st_Cid
+
+// st_UnidadeMedidaMedicamento
+type UnidadeMedidaMedicamento uint8
+
+var unidadeMedidaMedicamento = map[UnidadeMedidaMedicamento]string{
+	1: "Caixas",
+	2: "Frascos",
+}
+
+func (s UnidadeMedidaMedicamento) String() string {
+	return unidadeMedidaMedicamento[s]
+}


### PR DESCRIPTION
A proposta de implementação dos SimpleType do arquivo `schemas/sngpcSimpleTypes.xsd.xml`.

A ideia é que todo SimpleType seja um `type` Go, e quando for um enumerável, será implementar o acesso ao `simpleType map[]` via comando `String()`.