### PR TITLE
implementado sngpc.fromXML(io.Reader, interface{})

### DIFF
--- a/sngpc/sngpc.go
+++ b/sngpc/sngpc.go
@@ -2,6 +2,7 @@ package sngpc
 
 import (
 	"encoding/xml"
+	"io"
 	"os"
 
 	"golang.org/x/net/html/charset"
@@ -45,7 +46,11 @@ func loadFromXMLPath(path string, o interface{}) error {
 	}
 	defer f.Close()
 
-	dec := xml.NewDecoder(f)
+	return fromXML(f, &o)
+}
+
+func fromXML(r io.Reader, o interface{}) error {
+	dec := xml.NewDecoder(r)
 	dec.CharsetReader = charset.NewReaderLabel
 	return dec.Decode(o)
 }


### PR DESCRIPTION
o objetivo é poder usar esta função nos testes passando strings ou arquivos