### PR TITLE
WIP: Permitir exportar operações de venda para CSV opcionalmente de forma anônima

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/endersonmaia/sngpc-go/sngpc"
 	flag "github.com/spf13/pflag"
@@ -11,11 +13,15 @@ import (
 var (
 	isInventario bool
 	arquivoFlag  string
+	toCSV        bool
+	anonymize    bool
 )
 
 func init() {
 	flag.BoolVarP(&isInventario, "inventario", "i", false, "arquivo SNGPC de inventário")
 	flag.StringVar(&arquivoFlag, "arquivo", "", "caminho para um arquivo XML (Ex.: --from sngpc.xml)")
+	flag.BoolVarP(&toCSV, "csv", "", false, "formato de exportaçao")
+	flag.BoolVarP(&anonymize, "anonymise", "", false, "anonimizar os dados exportados")
 }
 
 func main() {
@@ -38,6 +44,16 @@ func main() {
 		if err != nil {
 			log.Panic(err)
 		}
-		fmt.Print(&m)
+
+		if toCSV {
+			writer := csv.NewWriter(os.Stdout)
+			if anonymize {
+				m.VendasToCSVAnonymized(writer)
+			} else {
+				m.VendasToCSV(writer)
+			}
+		} else {
+			fmt.Print(&m)
+		}
 	}
 }

--- a/sngpc/complex_types.go
+++ b/sngpc/complex_types.go
@@ -1,5 +1,7 @@
 package sngpc
 
+import "fmt"
+
 type Medicamento struct {
 	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
 	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
@@ -29,6 +31,16 @@ type Medicamentos struct {
 	EntradaMedicamentoTransformacao                []EntradaMedicamentoTransformacao                `xml:"entradaMedicamentoTransformacao"`
 	SaidaMedicamentoTransformacaoVendaAoConsumidor []SaidaMedicamentoTransformacaoVendaAoConsumidor `xml:"saidaMedicamentoTransformacaoVendaAoConsumidor"`
 	SaidaMedicamentoTransformacaoPerda             []SaidaMedicamentoTransformacaoPerda             `xml:"saidaMedicamentoTransformacaoPerda"`
+}
+
+func (s Medicamentos) String() string {
+	out := ""
+
+	for _, e := range s.EntradaMedicamentos {
+		out += fmt.Sprint(e.MedicamentoEntrada)
+	}
+
+	return out
 }
 
 //MedicamentoVenda
@@ -65,6 +77,10 @@ type MedicamentoEntrada struct {
 	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
 	QuantidadeMedicamento    uint                     `xml:"quantidadeMedicamento"`
 	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
+}
+
+func (s MedicamentoEntrada) String() string {
+	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v\n", s.RegistroMSMedicamento, s.NumeroLoteMedicamento, s.QuantidadeMedicamento)
 }
 
 //NotaFiscal

--- a/sngpc/complex_types.go
+++ b/sngpc/complex_types.go
@@ -1,14 +1,5 @@
 package sngpc
 
-//Medicamento
-// <complexType name="ct_Medicamento">
-//     <sequence>
-//       <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
-//       <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
-//       <element name="quantidadeMedicamento" type="sngpc:st_QuantidadeMedicamento" />
-//       <element name="unidadeMedidaMedicamento" type="sngpc:st_UnidadeMedidaMedicamento" />
-//     </sequence>
-//   </complexType>
 type Medicamento struct {
 	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
 	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
@@ -87,22 +78,14 @@ type MedicamentoEntrada struct {
 // </sequence>
 // </complexType>
 type NotaFiscal struct {
-	NumeroNotaFiscal       string `xml:"numeroNotaFiscal"`
-	TipoOperacaoNotaFiscal uint8  `xml:"tipoOperacaoNotaFiscal"`
-	DataNotaFiscal         string `xml:"dataNotaFiscal"`
-	CnpjOrigem             string `xml:"cnpjOrigem"`
-	CnpjDestino            string `xml:"cnpjDestino"`
+	NumeroNotaFiscal       string                 `xml:"numeroNotaFiscal"`
+	TipoOperacaoNotaFiscal TipoOperacaoNotaFiscal `xml:"tipoOperacaoNotaFiscal"`
+	DataNotaFiscal         string                 `xml:"dataNotaFiscal"`
+	CnpjOrigem             string                 `xml:"cnpjOrigem"`
+	CnpjDestino            string                 `xml:"cnpjDestino"`
 }
 
-//MedicamentoSaidaTransformacao
-// <complexType name="ct_MedicamentoSaidaTransformacao">
-// <sequence>
-//   <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
-//   <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
-//   <element name="quantidadeInsumo" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="unidadeDeMedidaDoInsumo" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
+// MedicamentoSaidaTransformacao
 type MedicamentoSaidaTransformacao struct {
 	RegistroMSMedicamento   string            `xml:"registroMSMedicamento"`
 	NumeroLoteMedicamento   string            `xml:"numeroLoteMedicamento"`
@@ -110,17 +93,7 @@ type MedicamentoSaidaTransformacao struct {
 	UnidadeDeMedidaDoInsumo TipoUnidadeInsumo `xml:"unidadeDeMedidaDoInsumo"`
 }
 
-//MedicamentoTransformacao
-// <complexType name="ct_MedicamentoTransformacao">
-// <sequence>
-//   <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
-//   <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
-//   <element name="quantidadeMedicamento" type="sngpc:st_QuantidadeMedicamento" />
-//   <element name="unidadeMedidaMedicamento" type="sngpc:st_UnidadeMedidaMedicamento" />
-//   <element name="quantidadeInsumo" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="unidadeDeMedidaDoInsumo" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
+// MedicamentoTransformacao
 type MedicamentoTransformacao struct {
 	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
 	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
@@ -130,18 +103,7 @@ type MedicamentoTransformacao struct {
 	UnidadeDeMedidaDoInsumo  TipoUnidadeInsumo        `xml:"unidadeDeMedidaDoInsumo"`
 }
 
-//MedicamentoTransformacaoVenda
-// <complexType name="ct_MedicamentoTransformacaoVenda">
-// <sequence>
-//   <element name="usoProlongado" type="sngpc:st_SimNaoNull"/>
-//   <element name="registroMSMedicamento" type="sngpc:st_RegistroMS" />
-//   <element name="numeroLoteMedicamento" type="sngpc:st_Lote" />
-//   <element name="quantidadeDeInsumoPorUnidadeFarmacotecnica" type="sngpc:st_QuantidadeDeInsumoPorUnidadeFarmacotecnica" />
-//   <element name="unidadeDeMedidaDoInsumo" type="sngpc:st_TipoUnidadeInsumo" />
-//   <element name="unidadeFarmacotecnica" type="sngpc:st_TipoUnidadeFarmacotecnica" />
-//   <element name="quantidadeDeUnidadesFarmacotecnicas" type="sngpc:st_QuantidadeDeUnidadesFarmacotecnicas" />
-// </sequence>
-// </complexType>
+// MedicamentoTransformacaoVenda
 type MedicamentoTransformacaoVenda struct {
 	UsoProlongado                              string                    `xml:"usoProlongado"`
 	RegistroMSMedicamento                      string                    `xml:"registroMSMedicamento"`
@@ -152,73 +114,35 @@ type MedicamentoTransformacaoVenda struct {
 	QuantidadeDeUnidadesFarmacotecnicas        float32                   `xml:"quantidadeDeUnidadesFarmacotecnicas"`
 }
 
-//Insumo
-// <complexType name="ct_Insumo">
-// <sequence>
-//   <element name="codigoInsumo" type="sngpc:st_CodigoDCB" />
-//   <element name="numeroLoteInsumo" type="sngpc:st_Lote" />
-//   <element name="insumoCNPJFornecedor" type="sngpc:st_CNPJ" />
-// </sequence>
-// </complexType>
+// Insumo
 type Insumo struct {
 	CodigoInsumo         string `xml:"codigoInsumo"`
 	NumeroLoteInsumo     string `xml:"numeroLoteInsumo"`
 	InsumoCNPJFornecedor string `xml:"insumoCNPJFornecedor"`
 }
 
-//InsumoEntrada
-// <complexType name="ct_InsumoEntrada">
-//     <sequence>
-//       <element name="insumoEntrada" type="sngpc:ct_Insumo" />
-//       <element name="quantidadeInsumoEntrada" type="sngpc:st_QuantidadeInsumo" />
-//       <element name="tipoUnidadeEntrada" type="sngpc:st_TipoUnidadeInsumo" />
-//     </sequence>
-//   </complexType>
+// InsumoEntrada
 type InsumoEntrada struct {
 	InsumoEntrada           Insumo            `xml:"insumoEntrada"`
 	QuantidadeInsumoEntrada float32           `xml:"quantidadeInsumoEntrada"`
 	TipoUnidadeEntrada      TipoUnidadeInsumo `xml:"tipoUnidadeEntrada"`
 }
 
-//InsumoTransferencia
-// <complexType name="ct_InsumoTransferencia">
-// <sequence>
-//   <element name="insumoTransferencia" type="sngpc:ct_Insumo" />
-//   <element name="quantidadeInsumoTransferencia" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="tipoUnidadeTransferencia" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
+// InsumoTransferencia
 type InsumoTransferencia struct {
 	InsumoTransferencia           Insumo            `xml:"insumoTransferencia"`
 	QuantidadeInsumoTransferencia float32           `xml:"quantidadeInsumoTransferencia"`
 	TipoUnidadeTransferencia      TipoUnidadeInsumo `xml:"tipoUnidadeTransferencia"`
 }
 
-//InsumoPerda
-// <complexType name="ct_InsumoPerda">
-// <sequence>
-//   <element name="insumoPerda" type="sngpc:ct_Insumo" />
-//   <element name="quantidadeInsumoPerda" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="tipoUnidadePerda" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
+// InsumoPerda
 type InsumoPerda struct {
 	InsumoPerda           Insumo            `xml:"insumoPerda"`
 	QuantidadeInsumoPerda float32           `xml:"quantidadeInsumoPerda"`
 	TipoUnidadePerda      TipoUnidadeInsumo `xml:"tipoUnidadePerda"`
 }
 
-//InsumoVendaAoConsumidor
-// <complexType name="ct_InsumoVendaAoConsumidor">
-// <sequence>
-//   <element name = "usoProlongado" type = "sngpc:st_SimNaoNull"/>
-//   <element name="insumoVendaAoConsumidor" type="sngpc:ct_Insumo" />
-//   <element name="quantidadeDeInsumoPorUnidadeFarmacotecnica" type="sngpc:st_QuantidadeDeInsumoPorUnidadeFarmacotecnica" />
-//   <element name="unidadeDeMedidaDoInsumo" type="sngpc:st_TipoUnidadeInsumo" />
-//   <element name="unidadeFarmacotecnica" type="sngpc:st_TipoUnidadeFarmacotecnica" />
-//   <element name="quantidadeDeUnidadesFarmacotecnicas" type="sngpc:st_QuantidadeDeUnidadesFarmacotecnicas" />
-// </sequence>
-// </complexType>
+// InsumoVendaAoConsumidor
 type InsumoVendaAoConsumidor struct {
 	UsoProlongado                              uint8                     `xml:"usoProlongado"`
 	InsumoVendaAoConsumidor                    Insumo                    `xml:"insumoVendaAoConsumidor"`
@@ -228,16 +152,7 @@ type InsumoVendaAoConsumidor struct {
 	QuantidadeDeUnidadesFarmacotecnicas        float32                   `xml:"quantidadeDeUnidadesFarmacotecnicas"`
 }
 
-//Comprador
-// <complexType name="ct_Comprador">
-// <sequence>
-//   <element name="nomeComprador" type="sngpc:st_Nome" />
-//   <element name="tipoDocumento" type="sngpc:st_TipoDocumento" />
-//   <element name="numeroDocumento" type="sngpc:st_NumeroDocumento" />
-//   <element name="orgaoExpedidor" type="sngpc:st_OrgaoExpedidor" />
-//   <element name="UFEmissaoDocumento" type="sngpc:st_UF" />
-// </sequence>
-// </complexType>
+// Comprador
 type Comprador struct {
 	NomeComprador      string         `xml:"nomeComprador"`
 	TipoDocumento      TipoDocumento  `xml:"tipoDocumento"`
@@ -246,15 +161,7 @@ type Comprador struct {
 	UFEmissaoDocumento UF             `xml:"UFEmissaoDocumento"`
 }
 
-//Prescritor
-// <complexType name="ct_Prescritor">
-//     <sequence>
-//       <element name="nomePrescritor" type="sngpc:st_Nome" />
-//       <element name="numeroRegistroProfissional" type="sngpc:st_NumeroDocumento" />
-//       <element name="conselhoProfissional" type="sngpc:st_ConselhoProfissional" />
-//       <element name="UFConselho" type="sngpc:st_UF" />
-//     </sequence>
-//   </complexType>
+// Prescritor
 type Prescritor struct {
 	NomePrescritor             string               `xml:"nomePrescritor"`
 	NumeroRegistroProfissional string               `xml:"numeroRegistroProfissional"`
@@ -277,16 +184,7 @@ type Prescritor struct {
 // </sequence>
 // </complexType>
 
-//Paciente
-// <complexType name="ct_paciente">
-// <sequence>
-//   <element name="nome" type="sngpc:st_Nome" />
-//   <element name="idade" type="sngpc:st_Idade" />
-//   <element name="unidadeIdade" type="sngpc:st_UnidadeIdade" />
-//   <element name="sexo" type="sngpc:st_Sexo" />
-//   <element name="cid" type="sngpc:st_Cid" />
-// </sequence>
-// </complexType>
+// Paciente
 type Paciente struct {
 	Nome         string       `xml:"nome"`
 	Idade        string       `xml:"idade"`
@@ -295,16 +193,7 @@ type Paciente struct {
 	Cid          string       `xml:"cid"`
 }
 
-//InsumoBasico
-// <complexType name="ct_InsumoBasico">
-// <sequence>
-//   <element name="codigoInsumo" type="sngpc:st_CodigoDCB" />
-//   <element name="numeroLoteInsumo" type="sngpc:st_Lote" />
-//   <element name="insumoCNPJFornecedor" type="sngpc:st_CNPJ" />
-//   <element name="quantidadeInsumo" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="tipoUnidade" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
+// InsumoBasico
 type InsumoBasico struct {
 	CodigoInsumo         string            `xml:"codigoInsumo"`
 	NumeroLoteInsumo     string            `xml:"numeroLoteInsumo"`

--- a/sngpc/complex_types.go
+++ b/sngpc/complex_types.go
@@ -5,7 +5,7 @@ import "fmt"
 type Medicamento struct {
 	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
 	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
-	QuantidadeMedicamento    string                   `xml:"quantidadeMedicamento"`
+	QuantidadeMedicamento    uint                     `xml:"quantidadeMedicamento"`
 	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
 }
 
@@ -113,7 +113,7 @@ type MedicamentoSaidaTransformacao struct {
 type MedicamentoTransformacao struct {
 	RegistroMSMedicamento    string                   `xml:"registroMSMedicamento"`
 	NumeroLoteMedicamento    string                   `xml:"numeroLoteMedicamento"`
-	QuantidadeMedicamento    string                   `xml:"quantidadeMedicamento"`
+	QuantidadeMedicamento    uint                     `xml:"quantidadeMedicamento"`
 	UnidadeMedidaMedicamento UnidadeMedidaMedicamento `xml:"unidadeMedidaMedicamento"`
 	QuantidadeInsumo         float32                  `xml:"quantidadeInsumo"`
 	UnidadeDeMedidaDoInsumo  TipoUnidadeInsumo        `xml:"unidadeDeMedidaDoInsumo"`

--- a/sngpc/inventario.go
+++ b/sngpc/inventario.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 )
 
-// MensagemSNGPCInventario
+// MensagemSNGPCInventario armazena o conteúdo de um arquivo de inventário do SNGPC
+// O arquivo de inventário contém uma data de referência e os registros de inventário
+// para medicamentos e insumos
 type MensagemSNGPCInventario struct {
 	XMLName   xml.Name            `xml:"mensagemSNGPCInventario"`
 	Cabecalho CabecalhoInventario `xml:"cabecalho"`
@@ -16,6 +18,7 @@ func (s MensagemSNGPCInventario) String() string {
 	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
 }
 
+// CabecalhoInventario armazena informações do arquivo de inventário
 type CabecalhoInventario struct {
 	CnpjEmissor    string `xml:"cnpjEmissor"`
 	CpfTransmissor string `xml:"cpfTransmissor"`
@@ -26,6 +29,7 @@ func (s CabecalhoInventario) String() string {
 	return fmt.Sprintf("Inventário :\n\nCNPJ : %v ; CPF : %v ; Data : %v\n", s.CnpjEmissor, s.CpfTransmissor, s.Data)
 }
 
+// CorpoInventario armazena informações dos registros de inventário
 type CorpoInventario struct {
 	Medicamentos Medicamentos `xml:"medicamentos"`
 	Insumos      Insumos      `xml:"insumos"`
@@ -39,17 +43,7 @@ func (s MedicamentoEntrada) String() string {
 	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v\n", s.RegistroMSMedicamento, s.NumeroLoteMedicamento, s.QuantidadeMedicamento)
 }
 
-//InsumoBasicoEntrada
-// <complexType name="ct_InsumoBasicoEntrada">
-// <sequence>
-//   <element name="classeTerapeutica" type="sngpc:st_classeTerapeutica" />
-//   <element name="codigoInsumo" type="sngpc:st_CodigoDCB" />
-//   <element name="numeroLoteInsumo" type="sngpc:st_Lote" />
-//   <element name="insumoCNPJFornecedor" type="sngpc:st_CNPJ" />
-//   <element name="quantidadeInsumo" type="sngpc:st_QuantidadeInsumo" />
-//   <element name="tipoUnidade" type="sngpc:st_TipoUnidadeInsumo" />
-// </sequence>
-// </complexType>
+// InsumoBasicoEntrada armazena os registros de entrada de insumos do inventário
 type InsumoBasicoEntrada struct {
 	ClasseTerapeutica    ClasseTerapeutica `xml:"classeTerapeutica"`
 	CodigoInsumo         string            `xml:"codigoInsumo"`

--- a/sngpc/inventario.go
+++ b/sngpc/inventario.go
@@ -39,10 +39,6 @@ func (s CorpoInventario) String() string {
 	return fmt.Sprintf("Corpo : \n\nMedicamentos : \n%v\nInsumos : \n%v\n", s.Medicamentos, s.Insumos)
 }
 
-func (s MedicamentoEntrada) String() string {
-	return fmt.Sprintf("RegistroMS : %v, Lote : %v, Quantidade : %v\n", s.RegistroMSMedicamento, s.NumeroLoteMedicamento, s.QuantidadeMedicamento)
-}
-
 // InsumoBasicoEntrada armazena os registros de entrada de insumos do inventário
 type InsumoBasicoEntrada struct {
 	ClasseTerapeutica    ClasseTerapeutica `xml:"classeTerapeutica"`

--- a/sngpc/movimentacao.go
+++ b/sngpc/movimentacao.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 )
 
-// MensagemSNGPC
+// MensagemSNGPC armazena o conteúdo de um arquivo de movimentação do SNGPC
+// O arquivo contem informações da movimentação de medicamentos e insumos
+// de um determinado período
 type MensagemSNGPC struct {
 	XMLName   xml.Name              `xml:"mensagemSNGPC"`
 	Cabecalho CabecalhoMovimentacao `xml:"cabecalho"`
@@ -16,15 +18,7 @@ func (s MensagemSNGPC) String() string {
 	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
 }
 
-//CabecalhoMovimentacao
-// <complexType>
-// <sequence>
-//   <element name="cnpjEmissor" type="sngpc:st_CNPJ" />
-//   <element name="cpfTransmissor" type="sngpc:st_CPF" />
-//   <element name="dataInicio" type="sngpc:st_data" />
-//   <element name="dataFim" type="sngpc:st_data" />
-// </sequence>
-// </complexType>
+// CabecalhoMovimentacao armazena informações da movimentação
 type CabecalhoMovimentacao struct {
 	CnpjEmissor    string `xml:"cnpjEmissor"`
 	CpfTransmissor string `xml:"cpfTransmissor"`
@@ -36,7 +30,6 @@ func (s CabecalhoMovimentacao) String() string {
 	return fmt.Sprintf("cnpj : %v ; cpf : %v ; inicio : %v, fim : %v\n", s.CnpjEmissor, s.CpfTransmissor, s.DataInicio, s.DataFim)
 }
 
-//Corpo
 type CorpoMovimentacao struct {
 	Medicamentos Medicamentos `xml:"medicamentos"`
 	Insumos      Insumos      `xml:"insumos"`
@@ -63,17 +56,7 @@ func (s CorpoMovimentacao) String() string {
 	return out
 }
 
-//Insumos
-// <element name="insumos">
-// <complexType>
-//   <sequence>
-// 	<element name="entradaInsumos" type="sngpc:ct_EntradaInsumo" minOccurs="0" maxOccurs="unbounded" />
-// 	<element name="saidaInsumoVendaAoConsumidor" type="sngpc:ct_SaidaInsumoVenda" minOccurs="0" maxOccurs="unbounded" />
-// 	<element name="saidaInsumoTransferencia" type="sngpc:ct_SaidaInsumoTransferencia" minOccurs="0" maxOccurs="unbounded" />
-// 	<element name="saidaInsumoPerda" type="sngpc:ct_SaidaInsumoPerda" minOccurs="0" maxOccurs="unbounded" />
-//   </sequence>
-// </complexType>
-// </element>
+// Insumos armazena os diversos tipos de movimentações de insumos
 type Insumos struct {
 	EntradaInsumos               []EntradaInsumo            `xml:"entradaInsumos"`
 	SaidaInsumoVendaAoConsumidor []SaidaInsumoVenda         `xml:"saidaInsumoVendaAoConsumidor"`

--- a/sngpc/movimentacao.go
+++ b/sngpc/movimentacao.go
@@ -73,13 +73,3 @@ func (s Insumos) String() string {
 
 	return out
 }
-
-func (s Medicamentos) String() string {
-	out := ""
-
-	for _, e := range s.EntradaMedicamentos {
-		out += fmt.Sprint(e.MedicamentoEntrada)
-	}
-
-	return out
-}

--- a/sngpc/movimentacao.go
+++ b/sngpc/movimentacao.go
@@ -1,8 +1,10 @@
 package sngpc
 
 import (
+	"encoding/csv"
 	"encoding/xml"
 	"fmt"
+	"log"
 )
 
 // MensagemSNGPC armazena o conteúdo de um arquivo de movimentação do SNGPC
@@ -16,6 +18,137 @@ type MensagemSNGPC struct {
 
 func (s MensagemSNGPC) String() string {
 	return fmt.Sprintf("%v\n%v", s.Cabecalho, s.Corpo)
+}
+
+// VendasToCSV formata a operação SaidaMedicamentoVendaAoConsumidor
+func (s MensagemSNGPC) VendasToCSV(w *csv.Writer) error {
+	header := []string{
+		"tipoReceituarioMedicamento",
+		"numeroNotificacaoMedicamento",
+		"dataPrescricaoMedicamento",
+		"nomePrescritor",
+		"numeroRegistroProfissionalPrescritor",
+		"conselhoProfissionalPrescritor",
+		"UFConselhoPrescritor",
+		"usoMedicamento",
+		"nomeComprador",
+		"tipoDocumentoComprador",
+		"numeroDocumentoComprador",
+		"orgaoExpedidorComprador",
+		"UFEmissaoDocumentoComprador",
+		"nomePaciente",
+		"idadePaciente",
+		"unidadeIdadePaciente",
+		"sexoPaciente",
+		"cidPaciente",
+		"usoProlongadoMedicamento",
+		"registroMSMedicamento",
+		"numeroLoteMedicamento",
+		"quantidadeMedicamento",
+		"unidadeMedidaMedicamento",
+		"dataVendaMedicamento",
+	}
+
+	err := w.Write(header)
+	if err != nil {
+		log.Panic(err)
+		return err
+	}
+
+	for _, v := range s.Corpo.Medicamentos.SaidaMedicamentoVendaAoConsumidor {
+		for _, m := range v.MedicamentoVenda {
+			r := []string{
+				v.TipoReceituarioMedicamento.String(),
+				v.NumeroNotificacaoMedicamento,
+				v.DataPrescricaoMedicamento,
+				v.PrescritorMedicamento.NomePrescritor,
+				v.PrescritorMedicamento.NumeroRegistroProfissional,
+				v.PrescritorMedicamento.ConselhoProfissional.String(),
+				v.PrescritorMedicamento.UFConselho.String(),
+				v.UsoMedicamento.String(),
+				v.CompradorMedicamento.NomeComprador,
+				v.CompradorMedicamento.TipoDocumento.String(),
+				v.CompradorMedicamento.NumeroDocumento,
+				v.CompradorMedicamento.UFEmissaoDocumento.String(),
+				v.PacienteMedicamento.Nome,
+				v.PacienteMedicamento.Idade,
+				v.PacienteMedicamento.UnidadeIdade.String(),
+				v.PacienteMedicamento.Sexo.String(),
+				v.PacienteMedicamento.Cid,
+				m.UsoProlongado,
+				m.RegistroMSMedicamento,
+				m.NumeroLoteMedicamento,
+				string(m.QuantidadeMedicamento),
+				m.UnidadeMedidaMedicamento.String(),
+				v.DataVendaMedicamento,
+			}
+
+			w.Write(r)
+		}
+	}
+
+	w.Flush()
+
+	return nil
+}
+
+// VendasToCSVAnonymized formata a operação SaidaMedicamentoVendaAoConsumidor
+func (s MensagemSNGPC) VendasToCSVAnonymized(w *csv.Writer) error {
+	header := []string{
+		"tipoReceituarioMedicamento",
+		"numeroNotificacaoMedicamento",
+		"dataPrescricaoMedicamento",
+		"conselhoProfissionalPrescritor",
+		"UFConselhoPrescritor",
+		"usoMedicamento",
+		"UFEmissaoDocumentoComprador",
+		"idadePaciente",
+		"unidadeIdadePaciente",
+		"sexoPaciente",
+		"cidPaciente",
+		"usoProlongadoMedicamento",
+		"registroMSMedicamento",
+		"numeroLoteMedicamento",
+		"quantidadeMedicamento",
+		"unidadeMedidaMedicamento",
+		"dataVendaMedicamento",
+	}
+
+	err := w.Write(header)
+	if err != nil {
+		log.Panic(err)
+		return err
+	}
+
+	for _, v := range s.Corpo.Medicamentos.SaidaMedicamentoVendaAoConsumidor {
+		for _, m := range v.MedicamentoVenda {
+			r := []string{
+				v.TipoReceituarioMedicamento.String(),
+				v.NumeroNotificacaoMedicamento,
+				v.DataPrescricaoMedicamento,
+				v.PrescritorMedicamento.ConselhoProfissional.String(),
+				v.PrescritorMedicamento.UFConselho.String(),
+				v.UsoMedicamento.String(),
+				v.CompradorMedicamento.UFEmissaoDocumento.String(),
+				v.PacienteMedicamento.Idade,
+				v.PacienteMedicamento.UnidadeIdade.String(),
+				v.PacienteMedicamento.Sexo.String(),
+				v.PacienteMedicamento.Cid,
+				m.UsoProlongado,
+				m.RegistroMSMedicamento,
+				m.NumeroLoteMedicamento,
+				string(m.QuantidadeMedicamento),
+				m.UnidadeMedidaMedicamento.String(),
+				v.DataVendaMedicamento,
+			}
+
+			w.Write(r)
+		}
+	}
+
+	w.Flush()
+
+	return nil
 }
 
 // CabecalhoMovimentacao armazena informações da movimentação

--- a/sngpc/operacoes.go
+++ b/sngpc/operacoes.go
@@ -1,33 +1,13 @@
 package sngpc
 
-//EntradaMedicamentos
-// <complexType name = "ct_EntradaMedicamento">
-// <sequence>
-// 	<element name = "notaFiscalEntradaMedicamento" type = "sngpc:ct_NotaFiscal"/>
-// 	<element name = "medicamentoEntrada" type = "sngpc:ct_MedicamentoEntrada" minOccurs = "0" maxOccurs = "unbounded"/>
-// 	<element name = "dataRecebimentoMedicamento" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// EntradaMedicamentos
 type EntradaMedicamentos struct {
 	NotaFiscalEntradaMedicamento NotaFiscal           `xml:"notaFiscalEntradaMedicamento"`
 	MedicamentoEntrada           []MedicamentoEntrada `xml:"medicamentoEntrada"`
 	DataRecebimentoMedicamento   string               `xml:"dataRecebimentoMedicamento"`
 }
 
-//SaidaMedicamentoVendaAoConsumidor
-// <complexType name = "ct_SaidaMedicamentoVendaAoConsumidor">
-// <sequence>
-// 	<element name = "tipoReceituarioMedicamento" type = "sngpc:st_TipoReceituario"/>
-// 	<element name = "numeroNotificacaoMedicamento" type = "sngpc:st_Notificacao"/>
-// 	<element name = "dataPrescricaoMedicamento" type = "sngpc:st_data"/>
-// 	<element name = "prescritorMedicamento" type = "sngpc:ct_Prescritor"/>
-// 	<element name = "usoMedicamento" type = "sngpc:st_TipoUsoMedicamento"/>
-// 	<element name = "compradorMedicamento" type = "sngpc:ct_Comprador" minOccurs="0" maxOccurs="1" />
-// 	<element name = "pacienteMedicamento" type = "sngpc:ct_paciente" minOccurs="0" maxOccurs="1" />
-// 	<element name = "medicamentoVenda" type = "sngpc:ct_MedicamentoVenda" minOccurs = "0" maxOccurs = "unbounded" />
-// 	<element name = "dataVendaMedicamento" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// SaidaMedicamentoVendaAoConsumidor
 type SaidaMedicamentoVendaAoConsumidor struct {
 	TipoReceituarioMedicamento   uint8              `xml:"tipoReceituarioMedicamento"`
 	NumeroNotificacaoMedicamento string             `xml:"numeroNotificacaoMedicamento"`
@@ -40,60 +20,27 @@ type SaidaMedicamentoVendaAoConsumidor struct {
 	DataVendaMedicamento         string             `xml:"dataVendaMedicamento"`
 }
 
-//SaidaMedicamentoTransferencia
-// <complexType name = "ct_SaidaMedicamentoTransferencia">
-// <sequence>
-// 	<element name = "notaFiscalTransferenciaMedicamento" type = "sngpc:ct_NotaFiscal" />
-// 	<element name = "medicamentoTransferencia" type = "sngpc:ct_Medicamento" minOccurs = "0" maxOccurs = "unbounded"/>
-// 	<element name = "dataTransferenciaMedicamento" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// SaidaMedicamentoTransferencia
 type SaidaMedicamentoTransferencia struct {
 	NotaFiscalTransferenciaMedicamento NotaFiscal    `xml:"notaFiscalTransferenciaMedicamento"`
 	MedicamentoTransferencia           []Medicamento `xml:"medicamentoTransferencia"`
 	DataTransferenciaMedicamento       string        `xml:"dataTransferenciaMedicamento"`
 }
 
-//SaidaMedicamentoPerda
-// <complexType name = "ct_SaidaMedicamentoPerda">
-// <sequence>
-// 	<element name = "motivoPerdaMedicamento" type = "sngpc:st_TipoMotivoPerda"/>
-// 	<element name = "medicamentoPerda" type = "sngpc:ct_Medicamento"/>
-// 	<element name = "dataPerdaMedicamento" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// SaidaMedicamentoPerda
 type SaidaMedicamentoPerda struct {
 	MotivoPerdaMedicamento uint8       `xml:"motivoPerdaMedicamento"`
 	MedicamentoPerda       Medicamento `xml:"medicamentoPerda"`
 	DataPerdaMedicamento   string      `xml:"dataPerdaMedicamento"`
 }
 
-//EntradaMedicamentoTransformacao
-// <complexType name = "ct_EntradaMedicamentoTransformacao">
-// <sequence>
-// 	<element name = "medicamentoTransformacaoEntrada" type="sngpc:ct_MedicamentoTransformacao" minOccurs = "0" maxOccurs = "unbounded"/>
-// 	<element name = "dataTransformacaoEntrada" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// EntradaMedicamentoTransformacao
 type EntradaMedicamentoTransformacao struct {
 	MedicamentoTransformacaoEntrada []MedicamentoTransformacao `xml:"medicamentoTransformacaoEntrada"`
 	DataTransformacaoEntrada        string                     `xml:"DataTransformacaoEntrada"`
 }
 
-//SaidaMedicamentoTransformacaoVendaAoConsumidor
-// <complexType name = "ct_SaidaMedicamentoTransformacaoVendaAoConsumidor">
-// <sequence>
-// 	<element name = "tipoReceituarioMedicamento" type = "sngpc:st_TipoReceituario"/>
-// 	<element name = "numeroNotificacaoMedicamento" type = "sngpc:st_Notificacao"/>
-// 	<element name = "dataPrescricaoMedicamento" type = "sngpc:st_data"/>
-// 	<element name = "prescritorMedicamento" type = "sngpc:ct_Prescritor"/>
-// 	<element name = "usoMedicamento" type = "sngpc:st_TipoUsoMedicamento"/>
-// 	<element name = "compradorMedicamento" type = "sngpc:ct_Comprador" minOccurs="0" maxOccurs="1"/>
-// 	<element name = "pacienteMedicamento" type = "sngpc:ct_paciente" minOccurs="0" maxOccurs="1"/>
-// 	<element name = "medicamentoVenda" type = "sngpc:ct_MedicamentoTransformacaoVenda" minOccurs = "0" maxOccurs = "unbounded"/>
-// 	<element name = "dataVendaMedicamento" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// SaidaMedicamentoTransformacaoVendaAoConsumidor
 type SaidaMedicamentoTransformacaoVendaAoConsumidor struct {
 	TipoReceituarioMedicamento   uint8                           `xml:"tipoReceituarioMedicamento"`
 	NumeroNotificacaoMedicamento string                          `xml:"numeroNotificacaoMedicamento"`
@@ -106,15 +53,7 @@ type SaidaMedicamentoTransformacaoVendaAoConsumidor struct {
 	DataVendaMedicamento         string                          `xml:"dataVendaMedicamento"`
 }
 
-//SaidaMedicamentoTransformacaoPerda
-// <complexType name = "ct_SaidaMedicamentoTransformacaoPerda">
-// <sequence>
-// 	<!--<element name = "classeTerapeutica" type = "sngpc:st_classeTerapeutica"/>-->
-// 	<element name = "motivoPerdaMedicamento" type = "sngpc:st_TipoMotivoPerda"/>
-// 	<element name = "medicamentoPerda" type = "sngpc:ct_MedicamentoSaidaTransformacao"/>
-// 	<element name = "dataPerdaMedicamento" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// SaidaMedicamentoTransformacaoPerda
 type SaidaMedicamentoTransformacaoPerda struct {
 	ClasseTerapeutica      uint8                         `xml:"classeTerapeutica"`
 	MotivoPerdaMedicamento uint8                         `xml:"motivoPerdaMedicamento"`
@@ -122,14 +61,7 @@ type SaidaMedicamentoTransformacaoPerda struct {
 	DataPerdaMedicamento   string                        `xml:"dataPerdaMedicamento"`
 }
 
-//EntradaInsumo
-// <complexType name = "ct_EntradaInsumo">
-// 	<sequence>
-// 		<element name = "notaFiscalEntradaInsumo" type = "sngpc:ct_NotaFiscal"/>
-// 		<element name = "insumoEntrada" type = "sngpc:ct_InsumoBasicoEntrada" minOccurs = "0" maxOccurs = "unbounded" />
-// 		<element name = "dataRecebimentoInsumo" type = "sngpc:st_data"/>
-// 	</sequence>
-// </complexType>
+// EntradaInsumo
 type EntradaInsumo struct {
 	NotaFiscalEntradaInsumo NotaFiscal            `xml:"notaFiscalEntradaInsumo"`
 	InsumoEntrada           []InsumoBasicoEntrada `xml:"insumoEntrada"`
@@ -137,19 +69,6 @@ type EntradaInsumo struct {
 }
 
 // SaidaInsumoVenda
-// <complexType name = "ct_SaidaInsumoVenda">
-// <sequence>
-// 	<element name = "tipoReceituarioInsumo" type = "sngpc:st_TipoReceituario"/>
-// 	<element name = "numeroNotificacaoInsumo" type = "sngpc:st_Notificacao"/>
-// 	<element name = "dataPrescricaoInsumo" type = "sngpc:st_data"/>
-// 	<element name = "prescritorInsumo" type = "sngpc:ct_Prescritor"/>
-// 	<element name = "usoInsumo" type = "sngpc:st_TipoUsoMedicamento"/>
-// 	<element name = "compradorInsumo" type = "sngpc:ct_Comprador" minOccurs="0" maxOccurs="1"/>
-// 	<element name = "pacienteInsumo" type = "sngpc:ct_paciente" minOccurs="0" maxOccurs="1"/>
-// 	<element name = "substanciaInsumoVendaAoConsumidor" type = "sngpc:ct_InsumoVendaAoConsumidor" minOccurs = "0" maxOccurs = "unbounded"/>
-// 	<element name = "dataVendaInsumo" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
 type SaidaInsumoVenda struct {
 	TipoReceituarioInsumo             uint8                   `xml:"tipoReceituarioInsumo"`
 	NumeroNotificacaoInsumo           string                  `xml:"numeroNotificacaoInsumo"`
@@ -162,29 +81,14 @@ type SaidaInsumoVenda struct {
 	DataVendaInsumo                   string                  `xml:"dataVendaInsumo"`
 }
 
-//SaidaInsumoTransferencia
-// <complexType name = "ct_SaidaInsumoTransferencia">
-// <sequence>
-//   <element name = "notaFiscalTransferenciaInsumo" type = "sngpc:ct_NotaFiscal"/>
-//   <element name = "insumoTransferencia" type = "sngpc:ct_InsumoBasico" minOccurs="0" maxOccurs="unbounded" />
-//   <element name = "dataTransferenciaInsumo" type = "sngpc:st_data"/>
-// </sequence>
-// </complexType>
+// SaidaInsumoTransferencia
 type SaidaInsumoTransferencia struct {
 	NotaFiscalTransferenciaInsumo NotaFiscal     `xml:"notaFiscalTransferenciaInsumo"`
 	InsumoTransferencia           []InsumoBasico `xml:"insumoTransferencia"`
 	DataTransferenciaInsumo       string         `xml:"dataTransferenciaInsumo"`
 }
 
-//SaidaInsumoPerda
-// <complexType name = "ct_SaidaInsumoPerda">
-// <sequence>
-// 	<element name = "motivoPerdaInsumo" type = "sngpc:st_TipoMotivoPerda"/>
-// 	<element name = "substanciaInsumoPerda" type = "sngpc:ct_InsumoPerda"/>
-// 	<element name = "dataPerdaInsumo" type = "sngpc:st_data"/>
-// 	<element name = "insumoCNPJFornecedor" type = "sngpc:st_CNPJ"/>
-// </sequence>
-// </complexType>
+// SaidaInsumoPerda
 type SaidaInsumoPerda struct {
 	MotivoPerdaInsumo     uint8       `xml:"motivoPerdaInsumo"`
 	SubstanciaInsumoPerda InsumoPerda `xml:"substanciaInsumoPerda"`
@@ -192,22 +96,12 @@ type SaidaInsumoPerda struct {
 	InsumoCNPJFornecedor  string      `xml:"insumoCNPJFornecedor"`
 }
 
-//MedicamentoInventario
-// <complexType name = "ct_Medicamento_Inventario">
-// <sequence>
-// 	<element name = "medicamentoEntrada" type = "sngpc:ct_MedicamentoEntrada" />
-// </sequence>
-// </complexType>
+// MedicamentoInventario
 type MedicamentoInvenatario struct {
 	MedicamentoEntrada MedicamentoEntrada `xml:"medicamentoEntrada"`
 }
 
-//InsumoInventario
-// <complexType name = "ct_Insumo_Inventario">
-// <sequence>
-// 	<element name = "insumoEntrada" type = "sngpc:ct_InsumoBasicoEntrada"/>
-// </sequence>
-// </complexType>
+// InsumoInventario
 type InsumoInventario struct {
 	InsumoEntrada InsumoBasicoEntrada `xml:"insumoEntrada"`
 }

--- a/sngpc/operacoes.go
+++ b/sngpc/operacoes.go
@@ -9,11 +9,11 @@ type EntradaMedicamentos struct {
 
 // SaidaMedicamentoVendaAoConsumidor
 type SaidaMedicamentoVendaAoConsumidor struct {
-	TipoReceituarioMedicamento   uint8              `xml:"tipoReceituarioMedicamento"`
+	TipoReceituarioMedicamento   TipoReceituario    `xml:"tipoReceituarioMedicamento"`
 	NumeroNotificacaoMedicamento string             `xml:"numeroNotificacaoMedicamento"`
 	DataPrescricaoMedicamento    string             `xml:"dataPrescricaoMedicamento"`
 	PrescritorMedicamento        Prescritor         `xml:"prescritorMedicamento"`
-	UsoMedicamento               uint8              `xml:"usoMedicamento"`
+	UsoMedicamento               TipoUsoMedicamento `xml:"usoMedicamento"`
 	CompradorMedicamento         Comprador          `xml:"compradorMedicamento"`
 	PacienteMedicamento          Paciente           `xml:"pacienteMedicamento"`
 	MedicamentoVenda             []MedicamentoVenda `xml:"medicamentoVenda"`
@@ -65,7 +65,7 @@ type SaidaMedicamentoTransformacaoPerda struct {
 type EntradaInsumo struct {
 	NotaFiscalEntradaInsumo NotaFiscal            `xml:"notaFiscalEntradaInsumo"`
 	InsumoEntrada           []InsumoBasicoEntrada `xml:"insumoEntrada"`
-	dataRecebimentoInsumo   string                `xml:"dataRecebimentoInsumo"`
+	DataRecebimentoInsumo   string                `xml:"dataRecebimentoInsumo"`
 }
 
 // SaidaInsumoVenda

--- a/sngpc/simple_types.go
+++ b/sngpc/simple_types.go
@@ -1,6 +1,9 @@
 package sngpc
 
-//st_classeTerapeutica
+// ClasseTerapeutica
+//
+//	1: "Antimicrobiano"
+//	2: "Sujeito a Controle Especial"
 type ClasseTerapeutica uint8
 
 var classeTerapeutica = map[ClasseTerapeutica]string{
@@ -8,6 +11,7 @@ var classeTerapeutica = map[ClasseTerapeutica]string{
 	2: "Sujeito a Controle Especial",
 }
 
+// Retorna a descrição da classe terapêutica.
 func (s ClasseTerapeutica) String() string {
 	return classeTerapeutica[s]
 }
@@ -32,7 +36,13 @@ func (s ClasseTerapeutica) String() string {
 // st_QuantidadeDeInsumoPorUnidadeFarmacotecnica
 // st_QuantidadeDeUnidadesFarmacotecnicas
 
-//st_TipoReceituario
+// TipoReceituario
+//
+//	1: "Receita de Controle Especial em 2 vias (Receita Branca)"
+//	2: "Notificação de Receita B (Notificação Azul",
+//	3: "Notificação de Receita Especial (Notificação Branca)",
+//	4: "Notificação de Receita A (Notificação Amarela)",
+//	5: "Receita Antimicrobiano em 2 vias",
 type TipoReceituario uint8
 
 var tipoReceituario = map[TipoReceituario]string{
@@ -43,11 +53,14 @@ var tipoReceituario = map[TipoReceituario]string{
 	5: "Receita Antimicrobiano em 2 vias",
 }
 
+// Retorna a descrição do Tipo de Receituário.
 func (s TipoReceituario) String() string {
 	return tipoReceituario[s]
 }
 
-//st_TipoUsoMedicamento
+// TipoUsoMedicamento
+//	1: "Humano"
+// 	2: "Veterinário"
 type TipoUsoMedicamento uint8
 
 var tipoUsoMedicamento = map[TipoUsoMedicamento]string{
@@ -55,11 +68,15 @@ var tipoUsoMedicamento = map[TipoUsoMedicamento]string{
 	2: "Veterinário",
 }
 
+// Retorna a descrição do Tipo de Uso do Medicamento.
 func (s TipoUsoMedicamento) String() string {
 	return tipoUsoMedicamento[s]
 }
 
-// st_TipoOperacaoNotaFiscal
+// TipoOperacaoNotaFiscal
+//	1: "Compra"
+//	2: "Transferência"
+//	3: "Venda"
 type TipoOperacaoNotaFiscal uint8
 
 var tipoOperacaoNotaFiscal = map[TipoOperacaoNotaFiscal]string{
@@ -68,11 +85,18 @@ var tipoOperacaoNotaFiscal = map[TipoOperacaoNotaFiscal]string{
 	3: "Venda",
 }
 
+// Retorna a descrição do Tipo de Operação da Nota Fiscal
 func (s TipoOperacaoNotaFiscal) String() string {
 	return tipoOperacaoNotaFiscal[s]
 }
 
-// st_ConselhoProfissional
+// ConselhoProfissional
+//
+//	"CRM" : "Conselho Regional de Medicida"
+//	"CRMV": "Conselho Regional de Medicina Veterinária"
+//	"CRO" : "Conselho Regional de Odontologia"
+//	"CRF" : "Conselho Regional de Farmácia"
+//	"RMS" : "Programa Mais Medicos - Registro Ministério da Saúde"
 type ConselhoProfissional string
 
 var conselhoProfissional = map[ConselhoProfissional]string{
@@ -83,11 +107,39 @@ var conselhoProfissional = map[ConselhoProfissional]string{
 	"RMS":  "Programa Mais Medicos - Registro Ministério da Saúde",
 }
 
+// Retorna a descrição do Conselho Profissinal informado.
 func (s ConselhoProfissional) String() string {
 	return conselhoProfissional[s]
 }
 
-// st_UF
+// UF - Unidade Federativa
+//	"AC": "Acre"
+//	"AL": "Alagoas"
+//	"AM": "Amazonas"
+//	"AP": "Amapa"
+//	"BA": "Bahia"
+//	"CE": "Ceara"
+//	"DF": "Distrito Federal"
+//	"ES": "Espirito Santo"
+//	"GO": "Goias"
+//	"MA": "Maranhao"
+//	"MG": "Minas Gerais"
+//	"MS": "Mato Grosso do Sul"
+//	"MT": "Mato Grosso"
+//	"PA": "Para"
+//	"PB": "Paraiba"
+//	"PE": "Pernambuco"
+//	"PI": "Piaui"
+//	"PR": "Parana"
+//	"RJ": "Rio de Janeiro"
+//	"RN": "Rio Grande do Norte"
+//	"RO": "Rondonia"
+//	"RR": "Roraima"
+//	"RS": "Rio Grande do Sul"
+//	"SC": "Santa Catarina"
+//	"SE": "Sergipe"
+//	"SP": "Sao Paulo"
+//	"TO": "Tocantins"
 type UF string
 
 var uf = map[UF]string{
@@ -120,11 +172,22 @@ var uf = map[UF]string{
 	"TO": "Tocantins",
 }
 
+// Retorna o nome da Unidade Federativa correspondente à sigla informada
 func (s UF) String() string {
 	return uf[s]
 }
 
-// st_TipoMotivoPerda
+// TipoMotivoPerda
+// 1:  "Furto / Roubo"
+// 2:  "Avaria"
+// 3:  "Vencimento"
+// 4:  "Apreensão / Recolhimento pela Visa"
+// 5:  "Perda no processo"
+// 6:  "Coleta para controle de qualidade"
+// 7:  "Perda de exclusão da portaria 344"
+// 8:  "Por desvio de qualidade"
+// 9:  "Recolhimento do Fabricante"
+// 10: "Devolução ao fornecedor/distribuidora"
 type TipoMotivoPerda uint8
 
 var tipoMotivoPerda = map[TipoMotivoPerda]string{
@@ -140,11 +203,15 @@ var tipoMotivoPerda = map[TipoMotivoPerda]string{
 	10: "Devolução ao fornecedor/distribuidora",
 }
 
+// Retorna a descrição do Motivo da Perda
 func (s TipoMotivoPerda) String() string {
 	return tipoMotivoPerda[s]
 }
 
-// st_TipoUnidadeInsumo
+// TipoUnidadeInsumo
+//	1: "Grama"
+//	2: "Mililitro"
+//	3: "Unidade (U)"
 type TipoUnidadeInsumo uint8
 
 var tipoUnidadeInsumo = map[TipoUnidadeInsumo]string{
@@ -153,11 +220,16 @@ var tipoUnidadeInsumo = map[TipoUnidadeInsumo]string{
 	3: "Unidade (U)",
 }
 
+// Retorna a descrição do Tipo de Unidade de Insumo
 func (s TipoUnidadeInsumo) String() string {
 	return tipoUnidadeInsumo[s]
 }
 
-// st_TipoUnidadeFarmacotecnica
+// TipoUnidadeFarmacotecnica
+//	1: "Grama"
+//	2: "Cápsula"
+//	3: "Comprimido"
+//	4: "Mililitro"
 type TipoUnidadeFarmacotecnica uint8
 
 var tipoUnidadeFarmacotecnica = map[TipoUnidadeFarmacotecnica]string{
@@ -167,11 +239,32 @@ var tipoUnidadeFarmacotecnica = map[TipoUnidadeFarmacotecnica]string{
 	4: "Mililitro",
 }
 
+// Retorna a descrição do Tipo de Unidade Farmacotêcnica
 func (s TipoUnidadeFarmacotecnica) String() string {
 	return tipoUnidadeFarmacotecnica[s]
 }
 
-// st_TipoDocumento
+// TipoDocumento
+//	1:  "CARTEIRA DE REGISTRO PROFISSIONAL"
+//	2:  "CARTEIRA DE IDENTIDADE"
+//	4:  "PEDIDO DE AUTORIZAÇÃO DE TRABALHO"
+//	5:  "CERTIDÃO DE NASCIMENTO"
+//	6:  "CERTIDÃO DE CASAMENTO"
+//	7:  "CERTIFICADO DE RESERVISTA"
+//	8:  "CARTA PATENTE"
+//	10: "CERTIFICADO DE DISPENSA DE INCORPORAÇÃO"
+//	11: "CARTEIRA DE IDENTIDADE DO ESTRANGEIRO"
+//	13: "PASSAPORTE"
+//	14: "PROTOCOLO DA POLÍCIA FEDERAL"
+//	19: "INSCRIÇÃO ESTADUAL"
+//	20: "INSCRIÇÃO MUNICIPAL"
+//	21: "ALVARÁ/LICENÇA SANITÁRIA MUNICIPAL"
+//	22: "ALVARA/LICENÇA SANITÁRIA ESTADUAL"
+//	38: "AUTORIZAÇÃO DE FUNCIONAMENTO DE EMPRESA"
+//	39: "AUTORIZAÇÃO ESPECIAL DE FUNCIONAMENTO"
+//	40: "AUTORIZAÇÃO ESPECIAL SIMPLIFICADA"
+//	50: "CARTEIRA DE TRABALHO E PREVIDÊNCIA SOCIAL"
+//	62: "CADASTRO NACIONAL DE PESSOA JURIDICA"
 type TipoDocumento uint8
 
 var tipoDocumento = map[TipoDocumento]string{
@@ -197,11 +290,64 @@ var tipoDocumento = map[TipoDocumento]string{
 	62: "CADASTRO NACIONAL DE PESSOA JURIDICA",
 }
 
+// Retorna a descrição do Tipo do Documento
 func (s TipoDocumento) String() string {
 	return tipoDocumento[s]
 }
 
-// st_OrgaoExpedidor
+// OrgaoExpedidor
+//	"CRA":     "CONSELHO REGIONAL DE ADMINISTRAÇÃO"
+//	"CRE":     "CONSELHO REGIONAL DE ECONOMIA"
+//	"CREA":    "CONSELHO REG.DE ENG. ARQUIT. E AGRONOMIA"
+//	"CRF":     "CONSELHO REGIONAL DE FARMÁCIA"
+//	"DGPC":    "DIRETORIA GERAL DA POLÍCIA CIVIL"
+//	"DPF":     "DEPARTAMENTO DE POLÍCIA FEDERAL"
+//	"IDAMP":   "INSTITUTO IDENTIF. AROLDO MENDES PAIVA"
+//	"IFP":     "INSTITUTO FÉLIX PACHECO"
+//	"IN":      "IMPRENSA NACIONAL"
+//	"JUNTA":   "JUNTA"
+//	"MAER":    "MINISTÉRIO DA AERONÁUTICA"
+//	"MEX":     "MINISTÉRIO DO EXÉRCITO"
+//	"MM":      "MINISTÉRIO DA MARINHA"
+//	"OAB":     "ORDEM DOS ADVOGADOS DO BRASIL"
+//	"SEJSP":   "SECRETARIA DE EST. DA JUSTIÇA E SEG. PUB"
+//	"SES":     "SECRETARIA DE ESTADO DA SEGURANÇA"
+//	"SESP":    "SECRETARIA DO ESTADO SEG. PÚBLICA"
+//	"SJS":     "SECRETARIA DA JUSTIÇA E DA SEGURANÇA"
+//	"SJTC":    "SECR. DA JUST. DO TRAB. E DA CIDADANIA"
+//	"SSIPT":   "SECR.  DE SEG. E INFORM. POLÍCIA TÉCNICA"
+//	"SSP":     "SECRETARIA DE SEGURANÇA PÚBLICA"
+//	"VACIV":   "VARA CIVIL"
+//	"VAMEN":   "VARA DE MENORES"
+//	"PM":      "POLICIA MILITAR"
+//	"ITB":     "INSTITUTO TAVARES BURIL"
+//	"CRM":     "CONSELHO REGIONAL DE MEDICINA"
+//	"CBM":     "CORPO DE BOMBEIROS MILITAR"
+//	"DIC":     "DETRAN - DIRETORIA DE IDENTIFICAÇÃO CIVIL"
+//	"CFP":     "CONSELHO FEDERAL DE PSICOLOGIA"
+//	"CRO":     "CONSELHO REGIONAL DE ODONTOLOGIA"
+//	"COREN":   "CONSELHO REGIONAL DE ENFERMARIA"
+//	"CFN":     "CONSELHO FEDERAL DE NUTRICIONISTAS"
+//	"MRE":     "MINISTÉRIO DAS RELAÇÕES EXTERIORES"
+//	"CRCI":    "CONSELHO REG. DE CORRETORES DE IMÓVEIS"
+//	"CRB":     "CONSELHO REGIONAL DE BIOLOGIA"
+//	"CRN":     "CONSELHO REGIONAL DE NUTRIÇÃO"
+//	"CFE":     "CONSELHO FEDERAL DE ENFERMAGEM"
+//	"CRC":     "CONSELHO REGIONAL DE CONTABILIDADE"
+//	"CRP":     "CONSELHO REGIONAL DE PSICOLOGIA"
+//	"CRQ":     "CONSELHO REGIONAL DE QUIMICA"
+//	"ANVISA":  "AGÊNCIA NACIONAL DE VIGILÂNCIA SANITÁRIA"
+//	"GOVEST":  "GOVERNO DO ESTADO"
+//	"PREF":    "PREFEITURA"
+//	"CRBM":    "CONSELHO REGIONAL DE BIOMEDICINA"
+//	"IPF":     "INSTITUTO PEREIRA FAUSTINO"
+//	"CREFITO": "CONSELHO REGIONAL DE FISIOTERAPIA E TERAPIA OCUPACIONAL"
+//	"CRMV":    "CONSELHO REGIONAL DE MEDICINA VETERINÁRIA"
+//	"MTE":     "MINISTÉRIO DO TRABALHO E EMPREGO"
+//	"CRFA":    "CONSELHO REGIONAL DE FONOAUDIOLOGIA"
+//	"CORECON": "CONSELHO REGIONAL DE ECONOMIA"
+//	"SDS":     "SECRETARIA DE DESENVOLVIMENTO SOCIAL"
+//	"SRF":     "SECRETARIA DA RECEITA FEDERAL"
 type OrgaoExpedidor string
 
 var orgaoExpedidor = map[OrgaoExpedidor]string{
@@ -259,6 +405,7 @@ var orgaoExpedidor = map[OrgaoExpedidor]string{
 	"SRF":     "SECRETARIA DA RECEITA FEDERAL",
 }
 
+// Retorna a descrição do Orgão Expedidor
 func (s OrgaoExpedidor) String() string {
 	return orgaoExpedidor[s]
 }
@@ -268,7 +415,9 @@ func (s OrgaoExpedidor) String() string {
 // st_Idade
 type Idade uint8
 
-// st_UnidadeIdade
+// UnidadeIdade
+//	1: "Anos"
+//	2: "Meses
 type UnidadeIdade uint8
 
 var unidadeIdade = map[UnidadeIdade]string{
@@ -276,11 +425,14 @@ var unidadeIdade = map[UnidadeIdade]string{
 	2: "Meses",
 }
 
+// Retorna a descrição da Unidade da Idade
 func (s UnidadeIdade) String() string {
 	return unidadeIdade[s]
 }
 
-// st_Sexo
+// Sexo
+//	1: "Masculino"
+//	2: "Feminino"
 type Sexo uint8
 
 var sexo = map[Sexo]string{
@@ -288,13 +440,16 @@ var sexo = map[Sexo]string{
 	2: "Feminino",
 }
 
+// Retorna a descrição do Sexo
 func (s Sexo) String() string {
 	return sexo[s]
 }
 
 // st_Cid
 
-// st_UnidadeMedidaMedicamento
+// UnidadeMedidaMedicamento
+//	1: "Caixas"
+//	2: "Frascos"
 type UnidadeMedidaMedicamento uint8
 
 var unidadeMedidaMedicamento = map[UnidadeMedidaMedicamento]string{
@@ -302,6 +457,7 @@ var unidadeMedidaMedicamento = map[UnidadeMedidaMedicamento]string{
 	2: "Frascos",
 }
 
+// Retorna a descrição da Unidade de Medida do Medicamento
 func (s UnidadeMedidaMedicamento) String() string {
 	return unidadeMedidaMedicamento[s]
 }

--- a/sngpc/simple_types.go
+++ b/sngpc/simple_types.go
@@ -92,7 +92,7 @@ func (s TipoOperacaoNotaFiscal) String() string {
 
 // ConselhoProfissional
 //
-//	"CRM" : "Conselho Regional de Medicida"
+//	"CRM" : "Conselho Regional de Medicina"
 //	"CRMV": "Conselho Regional de Medicina Veterinária"
 //	"CRO" : "Conselho Regional de Odontologia"
 //	"CRF" : "Conselho Regional de Farmácia"
@@ -100,7 +100,7 @@ func (s TipoOperacaoNotaFiscal) String() string {
 type ConselhoProfissional string
 
 var conselhoProfissional = map[ConselhoProfissional]string{
-	"CRM":  "Conselho Regional de Medicida",
+	"CRM":  "Conselho Regional de Medicina",
 	"CRMV": "Conselho Regional de Medicina Veterinária",
 	"CRO":  "Conselho Regional de Odontologia",
 	"CRF":  "Conselho Regional de Farmácia",

--- a/sngpc/sngpc.go
+++ b/sngpc/sngpc.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-// http://portal.anvisa.gov.br/sngpc/desenvolvedores
-
+// SNGPCXMLVersion armazena a versão do XML do SNGPC
+// Ver: http://portal.anvisa.gov.br/sngpc/desenvolvedores
 const SNGPCXMLVersion = "2.0"
 
 type TipoMensagemSNGPC uint
@@ -19,6 +19,7 @@ const (
 	Inventario
 )
 
+// InventarioFromXMLPath lê o conteúdo de um XML SNGPC do tipo `MensagemSNGPCInventario`
 func InventarioFromXMLPath(path string) (msg MensagemSNGPCInventario, err error) {
 	msg = MensagemSNGPCInventario{}
 	err = loadFromXMLPath(path, &msg)
@@ -26,6 +27,7 @@ func InventarioFromXMLPath(path string) (msg MensagemSNGPCInventario, err error)
 	return
 }
 
+// MovimentoFromXMLPath lê o conteúdo de um XML SNGPC do tipo `MensagemSNGPC`
 func MovimentoFromXMLPath(path string) (msg MensagemSNGPC, err error) {
 	msg = MensagemSNGPC{}
 	err = loadFromXMLPath(path, &msg)

--- a/sngpc/sngpc.go
+++ b/sngpc/sngpc.go
@@ -1,3 +1,7 @@
+// Com este pacote é possível importar arquivos XML no formato SNGPC 2.0
+// para trabalhar com seus valores. Deve ser possível exportar para CSV
+// com enfaze em vários tipos de movimentação.
+//
 package sngpc
 
 import (


### PR DESCRIPTION
O objetivo deste PR é permitir exportar as operações de Vendas para CSV.

As operações de vendas são : 

- [x]  [SaidaMedicamentoVendaAoConsumidor](https://github.com/endersonmaia/sngpc-go/blob/d8680888397da29081d35e3b4a585a403b65e284/sngpc/operacoes.go#L31-L41)
- [ ]  [SaidaMedicamentoTransformacaoVendaAoConsumidor](https://github.com/endersonmaia/sngpc-go/blob/d8680888397da29081d35e3b4a585a403b65e284/sngpc/operacoes.go#L97-L107)

Foram adicionadas opções à CLI (`--csv`, `--anonymize`) para permitir exportar para CSV com opção de anonimizar os dados exportados.

Foi escolhido uma operação de venda, por ser a forma mais relevante de colher estatísticas de dispensação dos medicamente, e envolvem informações de prescritos e pacientes/compradores.

De acordo com o [Tipo do Receituário](https://github.com/endersonmaia/sngpc-go/blob/d8680888397da29081d35e3b4a585a403b65e284/sngpc/simple_types.go#L36-L44), será opcional as informações de Paciente e/ou Comprador, e isso pode gerar CSV com colunas vazias em alguns casos. Ver [PDF](http://www.anvisa.gov.br/sngpc/Documentos2012/Manual_SNGPC_2.0_2.pdf) página 11, itens 2 e 3.